### PR TITLE
Remove unncessary keys from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,6 @@
 {
-  "name": "netlify-shortener-example",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/runtime": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,23 +1,11 @@
 {
-  "name": "netlify-shortener-example",
-  "version": "1.0.0",
   "baseUrl": "https://shortener-demo.netlify.com",
-  "description": "",
-  "main": "index.js",
+  "private": true,
   "scripts": {
     "shorten": "netlify-shortener"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/kentcdodds/netlify-shortener-example.git"
-  },
-  "keywords": [],
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/kentcdodds/netlify-shortener-example/issues"
-  },
-  "homepage": "https://github.com/kentcdodds/netlify-shortener-example#readme",
   "devDependencies": {
     "netlify-shortener": "^1.0.1"
   }


### PR DESCRIPTION
If `private` is enabled, npm won’t warn about missing metadata.

If you want me to remove the author and license keys in favor of a LICENSE file, I can do that too.